### PR TITLE
mud-window: Update reconnect button on tab change

### DIFF
--- a/src/mud-window.c
+++ b/src/mud-window.c
@@ -731,6 +731,7 @@ mud_window_notebook_page_change(GtkNotebook *notebook, gpointer page, gint arg, 
 
         gtk_widget_set_sensitive(self->priv->menu_disconnect, connected);
         gtk_widget_set_sensitive(self->priv->toolbar_disconnect, connected);
+        gtk_widget_set_sensitive(self->priv->toolbar_reconnect, !connected);
 
         mud_window_toggle_input_mode(self, self->priv->current_view);
 


### PR DESCRIPTION
This makes the reconnect button reflect the state of the current connection view.